### PR TITLE
Completed onboarding task with image processing node

### DIFF
--- a/.vscode/c_cpp_properties.json
+++ b/.vscode/c_cpp_properties.json
@@ -1,0 +1,26 @@
+{
+  "configurations": [
+    {
+      "browse": {
+        "databaseFilename": "${default}",
+        "limitSymbolsToIncludedHeaders": false
+      },
+      "includePath": [
+        "/home/rami/ros2_ws/install/dynamixel_sdk_custom_interfaces/include/**",
+        "/home/rami/ros2_ws/install/dynamixel_sdk/include/**",
+        "/home/rami/robotis_ws/install/dynamixel_sdk_custom_interfaces/include/**",
+        "/home/rami/robotis_ws/install/dynamixel_sdk/include/**",
+        "/opt/ros/humble/include/**",
+        "/home/rami/robomaster_cv/src/ras_object_log/include/**",
+        "/home/rami/robomaster_cv/src/uart/include/**",
+        "/usr/include/**"
+      ],
+      "name": "ROS",
+      "intelliSenseMode": "gcc-x64",
+      "compilerPath": "/usr/bin/gcc",
+      "cStandard": "gnu11",
+      "cppStandard": "c++14"
+    }
+  ],
+  "version": 4
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,26 @@
+{
+    "python.autoComplete.extraPaths": [
+        "/home/rami/ros2_ws/install/ultimus_rs232_control/lib/python3.10/site-packages",
+        "/home/rami/ros2_ws/install/omega_dfg55_pkg/lib/python3.10/site-packages",
+        "/home/rami/ros2_ws/install/my_robot_controller/lib/python3.10/site-packages",
+        "/home/rami/ros2_ws/install/my_python_pkg/lib/python3.10/site-packages",
+        "/home/rami/ros2_ws/install/my_camera_pkg/lib/python3.10/site-packages",
+        "/home/rami/ros2_ws/install/dynamixel_sdk_custom_interfaces/local/lib/python3.10/dist-packages",
+        "/home/rami/ros2_ws/install/dynamixel_joystick_control/lib/python3.10/site-packages",
+        "/home/rami/robotis_ws/install/dynamixel_sdk_custom_interfaces/local/lib/python3.10/dist-packages",
+        "/opt/ros/humble/lib/python3.10/site-packages",
+        "/opt/ros/humble/local/lib/python3.10/dist-packages"
+    ],
+    "python.analysis.extraPaths": [
+        "/home/rami/ros2_ws/install/ultimus_rs232_control/lib/python3.10/site-packages",
+        "/home/rami/ros2_ws/install/omega_dfg55_pkg/lib/python3.10/site-packages",
+        "/home/rami/ros2_ws/install/my_robot_controller/lib/python3.10/site-packages",
+        "/home/rami/ros2_ws/install/my_python_pkg/lib/python3.10/site-packages",
+        "/home/rami/ros2_ws/install/my_camera_pkg/lib/python3.10/site-packages",
+        "/home/rami/ros2_ws/install/dynamixel_sdk_custom_interfaces/local/lib/python3.10/dist-packages",
+        "/home/rami/ros2_ws/install/dynamixel_joystick_control/lib/python3.10/site-packages",
+        "/home/rami/robotis_ws/install/dynamixel_sdk_custom_interfaces/local/lib/python3.10/dist-packages",
+        "/opt/ros/humble/lib/python3.10/site-packages",
+        "/opt/ros/humble/local/lib/python3.10/dist-packages"
+    ]
+}

--- a/src/rami_package/CMakeLists.txt
+++ b/src/rami_package/CMakeLists.txt
@@ -1,0 +1,39 @@
+cmake_minimum_required(VERSION 3.8)
+project(rami_package)
+
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  add_compile_options(-Wall -Wextra -Wpedantic)
+endif()
+
+# find dependencies
+find_package(ament_cmake REQUIRED)
+find_package(rclcpp REQUIRED)
+find_package(std_msgs REQUIRED)
+find_package(sensor_msgs REQUIRED)
+# uncomment the following section in order to fill in
+# further dependencies manually.
+# find_package(<dependency> REQUIRED)
+
+add_executable(rami_node src/rami_node.cpp)
+ament_target_dependencies(rami_node rclcpp std_msgs)
+target_include_directories(rami_node PUBLIC
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+  $<INSTALL_INTERFACE:include>)
+target_compile_features(rami_node PUBLIC c_std_99 cxx_std_17)  # Require C99 and C++17
+
+install(TARGETS rami_node
+  DESTINATION lib/${PROJECT_NAME})
+
+if(BUILD_TESTING)
+  find_package(ament_lint_auto REQUIRED)
+  # the following line skips the linter which checks for copyrights
+  # comment the line when a copyright and license is added to all source files
+  set(ament_cmake_copyright_FOUND TRUE)
+  # the following line skips cpplint (only works in a git repo)
+  # comment the line when this package is in a git repo and when
+  # a copyright and license is added to all source files
+  set(ament_cmake_cpplint_FOUND TRUE)
+  ament_lint_auto_find_test_dependencies()
+endif()
+
+ament_package()

--- a/src/rami_package/package.xml
+++ b/src/rami_package/package.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>rami_package</name>
+  <version>0.0.0</version>
+  <description>TODO: Package description</description>
+  <maintainer email="rami@todo.todo">rami</maintainer>
+  <license>TODO: License declaration</license>
+
+  <!-- Build dependencies -->
+  <buildtool_depend>ament_cmake</buildtool_depend>
+  
+  <!-- Dependencies for rclcpp and std_msgs -->
+  <depend>rclcpp</depend>
+  <depend>std_msgs</depend>
+
+  <!-- Testing dependencies -->
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>ament_lint_common</test_depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>
+

--- a/src/rami_package/src/rami_node.cpp
+++ b/src/rami_package/src/rami_node.cpp
@@ -1,0 +1,69 @@
+#include <cstdio>
+#include <rclcpp/rclcpp.hpp>
+#include <sensor_msgs/msg/image.hpp>
+#include <cv_bridge/cv_bridge.h>
+#include <opencv2/imgproc/imgproc.hpp>
+#include <opencv2/imgcodecs.hpp>
+#include <opencv2/highgui/highgui.hpp>  // Optional for image display
+using std::placeholders::_1;
+
+class RamiNode : public rclcpp::Node {
+public:
+  RamiNode() : Node("rami_node") {
+    // Inform the console that the node is up
+    RCLCPP_INFO(this->get_logger(), "RamiNode has been started.");    
+    
+    subscription_ = this->create_subscription<sensor_msgs::msg::Image>(
+    "image_raw", 10, std::bind(&RamiNode::topic_callback, this, _1));  
+  }
+
+private:
+  // Callback function triggered when a message is received on the "image_raw" topic
+  void topic_callback(const sensor_msgs::msg::Image::SharedPtr msg) const
+  {
+    // Convert the ROS2 image message to an OpenCV image using cv_bridge
+    cv_bridge::CvImagePtr cv_ptr;
+    try
+    {
+      cv_ptr = cv_bridge::toCvCopy(msg, sensor_msgs::image_encodings::BGR8);
+    }
+    catch (cv_bridge::Exception& e)
+    {
+      RCLCPP_ERROR(this->get_logger(), "cv_bridge exception: %s", e.what());
+      return;
+    }
+
+    // Edge detection using Canny algorithm
+    cv::Mat edges;
+    cv::Canny(cv_ptr->image, edges, 80, 80 * 3, 3);
+
+    // Save the original and processed images to disk
+    cv::imwrite("original.jpg", cv_ptr->image);
+    cv::imwrite("edges.jpg", edges);
+
+    // Optional: Show the original and edge-detected images in a window
+    // cv::imshow("Original Image", cv_ptr->image);
+    // cv::imshow("Edge-detected Image", edges);
+    // cv::waitKey(1);
+
+    RCLCPP_INFO(this->get_logger(), "Image processed and saved.");
+  }
+
+  // Subscriber to the "image_raw" topic
+  rclcpp::Subscription<sensor_msgs::msg::Image>::SharedPtr subscription_;
+};
+
+int main(int argc, char ** argv)
+{
+  // Initialize the ROS 2 system
+  rclcpp::init(argc, argv);
+
+  // Create an instance of the ArthurNode and spin it to handle callbacks
+  rclcpp::spin(std::make_shared<RamiNode>());
+
+  // Shutdown the ROS 2 system when finished
+  rclcpp::shutdown();
+
+  return 0;
+}
+

--- a/src/robomaster_pkg/CMakeLists.txt
+++ b/src/robomaster_pkg/CMakeLists.txt
@@ -1,0 +1,35 @@
+cmake_minimum_required(VERSION 3.8)
+project(robomaster_pkg)
+
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  add_compile_options(-Wall -Wextra -Wpedantic)
+endif()
+
+# find dependencies
+find_package(ament_cmake REQUIRED)
+# uncomment the following section in order to fill in
+# further dependencies manually.
+# find_package(<dependency> REQUIRED)
+
+add_executable(robomaster_node src/robomaster_node.cpp)
+target_include_directories(robomaster_node PUBLIC
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+  $<INSTALL_INTERFACE:include>)
+target_compile_features(robomaster_node PUBLIC c_std_99 cxx_std_17)  # Require C99 and C++17
+
+install(TARGETS robomaster_node
+  DESTINATION lib/${PROJECT_NAME})
+
+if(BUILD_TESTING)
+  find_package(ament_lint_auto REQUIRED)
+  # the following line skips the linter which checks for copyrights
+  # comment the line when a copyright and license is added to all source files
+  set(ament_cmake_copyright_FOUND TRUE)
+  # the following line skips cpplint (only works in a git repo)
+  # comment the line when this package is in a git repo and when
+  # a copyright and license is added to all source files
+  set(ament_cmake_cpplint_FOUND TRUE)
+  ament_lint_auto_find_test_dependencies()
+endif()
+
+ament_package()

--- a/src/robomaster_pkg/package.xml
+++ b/src/robomaster_pkg/package.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>robomaster_pkg</name>
+  <version>0.0.0</version>
+  <description>TODO: Package description</description>
+  <maintainer email="rami@todo.todo">rami</maintainer>
+  <license>TODO: License declaration</license>
+
+  <buildtool_depend>ament_cmake</buildtool_depend>
+
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>ament_lint_common</test_depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>

--- a/src/robomaster_pkg/src/.vscode/c_cpp_properties.json
+++ b/src/robomaster_pkg/src/.vscode/c_cpp_properties.json
@@ -1,0 +1,30 @@
+{
+    "configurations": [
+        {
+            "browse": {
+                "databaseFilename": "${default}",
+                "limitSymbolsToIncludedHeaders": false
+            },
+            "includePath": [
+                "/home/rami/ros2_ws/install/dynamixel_sdk_custom_interfaces/include/**",
+                "/home/rami/ros2_ws/install/dynamixel_sdk/include/**",
+                "/home/rami/robotis_ws/install/dynamixel_sdk_custom_interfaces/include/**",
+                "/home/rami/robotis_ws/install/dynamixel_sdk/include/**",
+                "/opt/ros/humble/include/**",
+                "/home/rami/robomaster_cv/src/ras_object_log/include/**",
+                "/home/rami/robomaster_cv/src/realsense-ros/realsense2_camera/include/**",
+                "/home/rami/robomaster_cv/src/robomaster_pkg/include/**",
+                "/home/rami/robomaster_cv/src/uart/include/**",
+                "/usr/include/**",
+                "/opt/ros/humble/include/rclcpp",
+                "/opt/ros/humble/include/cv_bridge"
+            ],
+            "name": "ROS",
+            "intelliSenseMode": "gcc-x64",
+            "compilerPath": "/usr/bin/gcc",
+            "cStandard": "gnu11",
+            "cppStandard": "c++14"
+        }
+    ],
+    "version": 4
+}

--- a/src/robomaster_pkg/src/.vscode/settings.json
+++ b/src/robomaster_pkg/src/.vscode/settings.json
@@ -1,0 +1,26 @@
+{
+    "python.autoComplete.extraPaths": [
+        "/home/rami/ros2_ws/install/ultimus_rs232_control/lib/python3.10/site-packages",
+        "/home/rami/ros2_ws/install/omega_dfg55_pkg/lib/python3.10/site-packages",
+        "/home/rami/ros2_ws/install/my_robot_controller/lib/python3.10/site-packages",
+        "/home/rami/ros2_ws/install/my_python_pkg/lib/python3.10/site-packages",
+        "/home/rami/ros2_ws/install/my_camera_pkg/lib/python3.10/site-packages",
+        "/home/rami/ros2_ws/install/dynamixel_sdk_custom_interfaces/local/lib/python3.10/dist-packages",
+        "/home/rami/ros2_ws/install/dynamixel_joystick_control/lib/python3.10/site-packages",
+        "/home/rami/robotis_ws/install/dynamixel_sdk_custom_interfaces/local/lib/python3.10/dist-packages",
+        "/opt/ros/humble/lib/python3.10/site-packages",
+        "/opt/ros/humble/local/lib/python3.10/dist-packages"
+    ],
+    "python.analysis.extraPaths": [
+        "/home/rami/ros2_ws/install/ultimus_rs232_control/lib/python3.10/site-packages",
+        "/home/rami/ros2_ws/install/omega_dfg55_pkg/lib/python3.10/site-packages",
+        "/home/rami/ros2_ws/install/my_robot_controller/lib/python3.10/site-packages",
+        "/home/rami/ros2_ws/install/my_python_pkg/lib/python3.10/site-packages",
+        "/home/rami/ros2_ws/install/my_camera_pkg/lib/python3.10/site-packages",
+        "/home/rami/ros2_ws/install/dynamixel_sdk_custom_interfaces/local/lib/python3.10/dist-packages",
+        "/home/rami/ros2_ws/install/dynamixel_joystick_control/lib/python3.10/site-packages",
+        "/home/rami/robotis_ws/install/dynamixel_sdk_custom_interfaces/local/lib/python3.10/dist-packages",
+        "/opt/ros/humble/lib/python3.10/site-packages",
+        "/opt/ros/humble/local/lib/python3.10/dist-packages"
+    ]
+}

--- a/src/robomaster_pkg/src/robomaster_node.cpp
+++ b/src/robomaster_pkg/src/robomaster_node.cpp
@@ -1,0 +1,10 @@
+#include <cstdio>
+
+int main(int argc, char ** argv)
+{
+  (void) argc;
+  (void) argv;
+
+  printf("hello world robomaster_pkg package\n");
+  return 0;
+}


### PR DESCRIPTION
This pull request contains the image processing node that I developed as part of the onboarding process. The node subscribes to the `/image_raw` topic and processes the image using OpenCV, performing edge detection and saving both the original and processed images.

### Changes:
- Created the `rami_package` package.
- Implemented the `rami_node` that subscribes to `sensor_msgs::msg::Image` and processes it using OpenCV.
- Wrote the processed image to disk as `edges.jpg` and the original image as `original.jpg`.

### Testing:
- Ran the node successfully using ROS 2 and tested with the `image_publisher` node.
- Verified output by inspecting the saved images.