### PR TITLE
Odometry Message

### DIFF
--- a/src/dji_serial/CMakeLists.txt
+++ b/src/dji_serial/CMakeLists.txt
@@ -10,6 +10,7 @@ find_package(ament_cmake REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(std_msgs REQUIRED)
 find_package(stampede_msgs REQUIRED)
+find_package(tf2 REQUIRED)
 
 # Build a library for the DJI Serial protocol functionality.
 add_library(${PROJECT_NAME}_lib
@@ -26,6 +27,10 @@ add_executable(test_serial
   src/test_serial.cpp
 )
 
+add_executable(pose_node
+  src/pose_node.cpp
+)
+
 target_include_directories(${PROJECT_NAME}_lib PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
   $<INSTALL_INTERFACE:include>
@@ -34,8 +39,9 @@ target_include_directories(${PROJECT_NAME}_lib PUBLIC
 ament_target_dependencies(${PROJECT_NAME}_lib rclcpp std_msgs stampede_msgs)
 ament_target_dependencies(dji_serial rclcpp std_msgs stampede_msgs)
 ament_target_dependencies(test_serial rclcpp std_msgs stampede_msgs)
+ament_target_dependencies(pose_node rclcpp std_msgs stampede_msgs tf2)
 
-install(TARGETS ${PROJECT_NAME}_lib dji_serial test_serial
+install(TARGETS ${PROJECT_NAME}_lib dji_serial test_serial pose_node
   DESTINATION lib/${PROJECT_NAME}
 )
 

--- a/src/dji_serial/package.xml
+++ b/src/dji_serial/package.xml
@@ -12,6 +12,9 @@
   <depend>rclcpp</depend>
   <depend>std_msgs</depend>
   <depend>stampede_msgs</depend>
+  <depend>tf2</depend>
+  <depend>tf2_ros</depend>
+  <depend>tf2_geometry_msgs</depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>

--- a/src/dji_serial/src/pose_node.cpp
+++ b/src/dji_serial/src/pose_node.cpp
@@ -1,0 +1,50 @@
+#include <rclcpp/rclcpp.hpp>
+#include <geometry_msgs/msg/pose_stamped.hpp>
+#include <stampede_msgs/msg/dji_packet.hpp>
+#include <stampede_msgs/msg/odometry_data.hpp>
+#include <tf2/LinearMath/Quaternion.h>
+
+#define MSG_TYPE_ODOMETRY_DATA 1
+
+class PoseNode : public rclcpp::Node {
+public:
+    PoseNode() : Node("pose_node") {
+        this->declare_parameter<std::string>("dji_rx_topic", "dji_tx");
+        this->declare_parameter<std::string>("odometry_topic", "odometry_data");
+        this->get_parameter("dji_rx_topic", dji_rx_topic_);
+        this->get_parameter("odometry_topic", odometry_topic_);
+
+        dji_rx_ = this->create_subscription<stampede_msgs::msg::DJIPacket>(
+            dji_rx_topic_, 10,
+            std::bind(&PoseNode::handle_dji_packet, this, std::placeholders::_1));
+        odom_pub_ = this->create_publisher<stampede_msgs::msg::OdometryData>(odometry_topic_, 10);
+    }
+
+private:
+    std::string dji_rx_topic_;
+    std::string odometry_topic_;
+    rclcpp::Subscription<stampede_msgs::msg::DJIPacket>::SharedPtr dji_rx_;
+    rclcpp::Publisher<stampede_msgs::msg::OdometryData>::SharedPtr odom_pub_;
+
+    void handle_dji_packet(const stampede_msgs::msg::DJIPacket::SharedPtr msg) {
+        if (msg->message_type == MSG_TYPE_ODOMETRY_DATA &&
+            msg->body.size() == sizeof(stampede_msgs::msg::OdometryData) - sizeof(std_msgs::msg::Header)) {
+            stampede_msgs::msg::OdometryData odom_msg;
+            odom_msg.header.stamp = this->now();
+            odom_msg.header.frame_id = "map";
+            std::memcpy(reinterpret_cast<uint8_t*>(&odom_msg) + sizeof(std_msgs::msg::Header),
+                        msg->body.data(),
+                        msg->body.size());
+            odom_pub_->publish(odom_msg);
+            RCLCPP_INFO(this->get_logger(), "Published OdometryData: (%.2f, %.2f, yaw=%.2f)", odom_msg.x_pos, odom_msg.y_pos, odom_msg.chassis_yaw);
+        }
+    }
+};
+
+int main(int argc, char **argv) {
+    rclcpp::init(argc, argv);
+    auto node = std::make_shared<PoseNode>();
+    rclcpp::spin(node);
+    rclcpp::shutdown();
+    return 0;
+}

--- a/src/dji_serial/src/pose_node.cpp
+++ b/src/dji_serial/src/pose_node.cpp
@@ -9,7 +9,7 @@
 class PoseNode : public rclcpp::Node {
 public:
     PoseNode() : Node("pose_node") {
-        this->declare_parameter<std::string>("dji_rx_topic", "dji_tx");
+        this->declare_parameter<std::string>("dji_rx_topic", "dji_rx");
         this->declare_parameter<std::string>("odometry_topic", "odometry_data");
         this->get_parameter("dji_rx_topic", dji_rx_topic_);
         this->get_parameter("odometry_topic", odometry_topic_);
@@ -37,6 +37,9 @@ private:
                         msg->body.size());
             odom_pub_->publish(odom_msg);
             RCLCPP_INFO(this->get_logger(), "Published OdometryData: (%.2f, %.2f, yaw=%.2f)", odom_msg.x_pos, odom_msg.y_pos, odom_msg.chassis_yaw);
+            RCLCPP_INFO(this->get_logger(), "Position: (%.2f, %.2f, %.2f)", odom_msg.x_pos, odom_msg.y_pos, odom_msg.z_pos);
+            RCLCPP_INFO(this->get_logger(), "Chassis Pitch: %.2f, Yaw: %.2f, Roll: %.2f", odom_msg.chassis_pitch, odom_msg.chassis_yaw, odom_msg.chassis_roll);
+            RCLCPP_INFO(this->get_logger(), "Turret Pitch: %.2f, Yaw: %.2f", odom_msg.turret_pitch, odom_msg.turret_yaw);
         }
     }
 };

--- a/src/rtt/package.xml
+++ b/src/rtt/package.xml
@@ -9,6 +9,9 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 
+  <depend>std_msgs</depend>
+  <depend>stampede_msgs</depend>
+
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>
 

--- a/src/rtt/src/rtt.cpp
+++ b/src/rtt/src/rtt.cpp
@@ -115,7 +115,7 @@ private:
             {
                 auto msg = std_msgs::msg::ByteMultiArray();
                 msg.data.insert(msg.data.end(), buffer, buffer + bytes_received);
-                RCLCPP_INFO(this->get_logger(), "Received: %.*s", msg.data.size(), msg.data.data());
+                RCLCPP_INFO(this->get_logger(), "Received: %.*s", (int) msg.data.size(), msg.data.data());
                 publisher_->publish(msg);
             }
             else if (bytes_received == 0)
@@ -150,7 +150,7 @@ private:
         }
         else
         {
-            RCLCPP_INFO(this->get_logger(), "Sent: %.*s", msg->data.size(), msg->data.data());
+            RCLCPP_INFO(this->get_logger(), "Sent: %.*s", (int) msg->data.size(), msg->data.data());
         }
     }
 

--- a/src/stampede_msgs/CMakeLists.txt
+++ b/src/stampede_msgs/CMakeLists.txt
@@ -11,6 +11,7 @@ find_package(ament_cmake REQUIRED)
 find_package(rosidl_default_generators REQUIRED)
 find_package(vision_msgs REQUIRED)
 find_package(geometry_msgs REQUIRED)
+find_package(std_msgs REQUIRED)
 # uncomment the following section in order to fill in
 # further dependencies manually.
 # find_package(<dependency> REQUIRED)
@@ -35,7 +36,7 @@ rosidl_generate_interfaces(${PROJECT_NAME}
   "msg/Uart.msg"
   "msg/TurretData.msg"
   "msg/OdometryData.msg"
-  DEPENDENCIES vision_msgs geometry_msgs
+  DEPENDENCIES std_msgs geometry_msgs vision_msgs
 )
 ament_export_dependencies(rosidl_default_runtime)
 

--- a/src/stampede_msgs/msg/OdometryData.msg
+++ b/src/stampede_msgs/msg/OdometryData.msg
@@ -1,10 +1,10 @@
-float32 xpos
-float32 ypos
-float32 zpos
+std_msgs/Header header
 
+float32 x_pos
+float32 y_pos
+float32 z_pos
 float32 chassis_pitch
 float32 chassis_yaw
 float32 chassis_roll
-
 float32 turret_pitch
 float32 turret_yaw

--- a/src/stampede_msgs/package.xml
+++ b/src/stampede_msgs/package.xml
@@ -17,6 +17,8 @@
   <buildtool_depend>rosidl_default_generators</buildtool_depend>
   <exec_depend>rosidl_default_runtime</exec_depend>
   <member_of_group>rosidl_interface_packages</member_of_group>
+  <build_depend>std_msgs</build_depend>
+  <exec_depend>std_msgs</exec_depend>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/src/uart/CMakeLists.txt
+++ b/src/uart/CMakeLists.txt
@@ -41,9 +41,19 @@ install(
 add_executable(uart
   src/uart.cpp
 )
+
+add_executable(simulate_uart_rx
+  src/simulate_uart_rx.cpp
+)
+
 ament_target_dependencies(uart
   ${DEPENDENCIES}
 )
+
+ament_target_dependencies(simulate_uart_rx
+  ${DEPENDENCIES}
+)
+
 target_link_libraries(uart
   serial
 )
@@ -55,6 +65,7 @@ target_include_directories(uart
 
 install(TARGETS
   uart
+  simulate_uart_rx
   DESTINATION lib/${PROJECT_NAME})
 
 install(

--- a/src/uart/src/simulate_uart_rx.cpp
+++ b/src/uart/src/simulate_uart_rx.cpp
@@ -1,0 +1,76 @@
+#include <rclcpp/rclcpp.hpp>
+#include <std_msgs/msg/byte_multi_array.hpp>
+#include <string>
+#include <vector>
+#include <sstream>
+#include <iomanip>
+#include <algorithm>
+
+// Helper: Convert hex string (e.g. "01A3FF") to std::vector<uint8_t>
+std::vector<uint8_t> hex_string_to_bytes(const std::string &hex) {
+    std::vector<uint8_t> bytes;
+    std::string clean_hex;
+    // Remove spaces
+    std::remove_copy_if(hex.begin(), hex.end(), std::back_inserter(clean_hex), ::isspace);
+    if (clean_hex.length() % 2 != 0) return bytes; // Invalid length
+
+    for (size_t i = 0; i < clean_hex.length(); i += 2) {
+        std::string byte_str = clean_hex.substr(i, 2);
+        uint8_t byte = static_cast<uint8_t>(std::stoul(byte_str, nullptr, 16));
+        bytes.push_back(byte);
+    }
+    return bytes;
+}
+
+class SimulateUartRxNode : public rclcpp::Node {
+public:
+    SimulateUartRxNode() : Node("simulate_uart_rx") {
+        publisher_ = this->create_publisher<std_msgs::msg::ByteMultiArray>("uart_rx", 10);
+
+        this->declare_parameter<std::string>("hex_bytes", "");
+        this->declare_parameter<double>("publish_rate", 1.0); // Default 1 Hz
+        std::string hex_bytes;
+        double publish_rate;
+        this->get_parameter("hex_bytes", hex_bytes);
+        this->get_parameter("publish_rate", publish_rate);
+
+        if (hex_bytes.empty()) {
+            RCLCPP_ERROR(this->get_logger(), "No hex_bytes parameter provided.");
+            rclcpp::shutdown();
+            return;
+        }
+
+        bytes_ = hex_string_to_bytes(hex_bytes);
+        if (bytes_.empty()) {
+            RCLCPP_ERROR(this->get_logger(), "Failed to parse hex_bytes: '%s'", hex_bytes.c_str());
+            rclcpp::shutdown();
+            return;
+        }
+
+        timer_ = this->create_wall_timer(
+            std::chrono::duration<double>(1.0 / publish_rate),
+            std::bind(&SimulateUartRxNode::timer_callback, this)
+        );
+    }
+
+private:
+    void timer_callback() {
+        std_msgs::msg::ByteMultiArray msg;
+        msg.data = bytes_;
+        std::ostringstream oss;
+        for (auto b : bytes_) oss << std::hex << std::setw(2) << std::setfill('0') << (int)b;
+        RCLCPP_INFO(this->get_logger(), "Publishing %zu bytes: %s", bytes_.size(), oss.str().c_str());
+        publisher_->publish(msg);
+    }
+
+    rclcpp::Publisher<std_msgs::msg::ByteMultiArray>::SharedPtr publisher_;
+    rclcpp::TimerBase::SharedPtr timer_;
+    std::vector<uint8_t> bytes_;
+};
+
+int main(int argc, char **argv) {
+    rclcpp::init(argc, argv);
+    auto node = std::make_shared<SimulateUartRxNode>();
+    rclcpp::spin(node);
+    return 0;
+}


### PR DESCRIPTION
# Motivation
<!--- explain the motivation -->
- Need to be able to receive odometry from the robot

# Changes
<!--- explain what changes are made -->
- Updated some DJI serial interfaces to be more clear
  - dji_tx is now transmitting messages *away* from the CV board and vice versa
- Added pose/odometry messages
- Tested mock receiving them locally

# Testing
<!--- explain the testing process and show examples (screenshots & videos) -->
Asked Suhas and Morris to generate a mock odometry message readout from the robot

See https://github.com/ut-ras/robomaster/commit/2bc9e00e4ccd559b06fa23a2338e486e0a6e1ac1 with some relevant bugfixes that Morris did (adding .c_str() to the hex string as I forgot it)
```
message size 32
odometry pointer (as uint8_t) 
0x10000AFB
odometry data (as a hex string) 
0000803f0000004000004040000080400000a0400000c0400000e04000000041
odometry message (as a hex string) a52000005701000000803f0000004000004040000080400000a0400000c0400000e0400000004105fe
END MESSAGE
```

Created simulate_uart_rx to simulate receiving hex UART bytestrings
```
ros2 run uart simulate_uart_rx --ros-args -p hex_bytes:=\"a52000005701000000803f0000004000004040000080400000a0400000c0400000e0400000004105fe\"
```

Ran dji_serial dji_serial and dji_serial pose_node in conjunction

<img width="640" alt="image" src="https://github.com/user-attachments/assets/d2507e9f-2bcb-4691-8208-d993fb1ca0ce" />

<img width="1219" alt="image" src="https://github.com/user-attachments/assets/346490df-dcbd-401d-b112-083706316585" />

<img width="686" alt="image" src="https://github.com/user-attachments/assets/907eba0f-23fb-4d05-b542-14d8bd927c2e" />

Successfully received expected values from message.